### PR TITLE
Ensure wget is installed

### DIFF
--- a/bin/adsblol-init
+++ b/bin/adsblol-init
@@ -16,7 +16,7 @@ if [ ! $(id -u) = 0 ]; then
     exit 1
 fi
 
-REQS="git jq bridge-utils rtl-sdr iptables"
+REQS="git jq bridge-utils rtl-sdr iptables wget"
 # Check if we have REQ, if not, install them
 for REQ in $REQS; do
     if ! dpkg -s $REQ >/dev/null 2>&1; then


### PR DESCRIPTION
The install script uses `wget` in many places, but doesn't ensure that it's installed. This fixes the discrepancy.

Signed-off-by: willmurnane <will.murnane@gmail.com>