### PR TITLE
update.sh: install python3-setuptools

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -61,7 +61,7 @@ function aptInstall() {
 }
 
 
-packages="git wget unzip curl build-essential python3-dev socat python3-venv ncurses-dev ncurses-bin uuid-runtime zlib1g-dev zlib1g"
+packages="git wget unzip curl build-essential python3-dev socat python3-venv python3-setuptools ncurses-dev ncurses-bin uuid-runtime zlib1g-dev zlib1g"
 if ! grep -E 'wheezy|jessie' /etc/os-release -qs; then
     packages+=" libzstd-dev libzstd1"
 fi


### PR DESCRIPTION
Possibly this was pulled in by one of the other packages but possibly not anymore. Maybe it's just Ubuntu doing it differently.